### PR TITLE
Fix error in coverage_content_type 

### DIFF
--- a/tests/base_roms_test.ncml
+++ b/tests/base_roms_test.ncml
@@ -22,7 +22,7 @@
 <variable name="Dwave">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
@@ -30,91 +30,91 @@
   <attribute name="standard_name" type="String" value="sea_surface_wave_significant_height"/>
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="Lwave">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="Ubot">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="Vbot">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="Zo_Nik">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="Zo_app">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="Zo_bedform">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="Zo_bedload">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="Zo_bio">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="Zo_def">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="Zo_wbl">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="active_layer_thickness">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="angle">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
@@ -123,263 +123,263 @@
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="coordinates" type="String" value="lon_rho lat_rho ocean_time Nbed"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="bed_wave_amp">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="bedload_Usand_01">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge1"/>
 </variable>
 
 <variable name="bedload_Usand_02">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge1"/>
 </variable>
 
 <variable name="bedload_Vsand_01">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge2"/>
 </variable>
 
 <variable name="bedload_Vsand_02">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge2"/>
 </variable>
 
 <variable name="bustr">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge1"/>
 </variable>
 
 <variable name="bustrc">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="bustrcwmax">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="bustrw">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="bvstr">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge2"/>
 </variable>
 
 <variable name="bvstrc">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="bvstrcwmax">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="bvstrw">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="dep_net">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="ero_flux">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="erosion_stress">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="f">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="gls">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="grain_density">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="grain_diameter">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="h">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="lat_psi">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
 </variable>
 
 <variable name="lat_rho">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="lat_u">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge1"/>
 </variable>
 
 <variable name="lat_v">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge2"/>
 </variable>
 
 <variable name="lon_psi">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
 </variable>
 
 <variable name="lon_rho">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="lon_u">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge1"/>
 </variable>
 
 <variable name="lon_v">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge2"/>
 </variable>
 
 <variable name="mask_psi">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
 </variable>
 
 <variable name="mask_rho">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="mask_u">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge1"/>
 </variable>
 
 <variable name="mask_v">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge2"/>
 </variable>
 
 <variable name="pm">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="pn">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="ripple_height">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="ripple_length">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
@@ -387,28 +387,28 @@
   <attribute name="standard_name" type="String" value="sea_water_salinity"/>
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="saltation">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="sand_01">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="sand_02">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
@@ -416,7 +416,7 @@
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="coordinates" type="String" value="lon_rho lat_rho ocean_time Nbed"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
@@ -424,7 +424,7 @@
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="coordinates" type="String" value="lon_rho lat_rho ocean_time Nbed"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
@@ -432,7 +432,7 @@
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="coordinates" type="String" value="lon_rho lat_rho ocean_time Nbed"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
@@ -440,28 +440,28 @@
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="coordinates" type="String" value="lon_rho lat_rho ocean_time Nbed"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="settling_vel">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="sustr">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge1"/>
 </variable>
 
 <variable name="svstr">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge2"/>
 </variable>
 
@@ -469,14 +469,14 @@
   <attribute name="standard_name" type="String" value="sea_water_potential_temperature"/>
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
 <variable name="tke">
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 
@@ -484,7 +484,7 @@
   <attribute name="standard_name" type="String" value="x_sea_water_velocity"/>
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge1"/>
 </variable>
 
@@ -492,7 +492,7 @@
   <attribute name="standard_name" type="String" value="barotropic_x_sea_water_velocity"/>
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="False"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge1"/>
 </variable>
 
@@ -500,7 +500,7 @@
   <attribute name="standard_name" type="String" value="y_sea_water_velocity"/>
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge2"/>
 </variable>
 
@@ -508,7 +508,7 @@
   <attribute name="standard_name" type="String" value="barotropic_y_sea_water_velocity"/>
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="False"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="edge2"/>
 </variable>
 
@@ -516,7 +516,7 @@
   <attribute name="standard_name" type="String" value="sea_surface_height_above_datum"/>
   <attribute name="grid" type="String" value="grid"/>
   <attribute name="display" type="String" value="True"/>
-  <attribute name="content_coverage_type" type="String" value="modelResult"/>
+  <attribute name="coverage_content_type" type="String" value="modelResult"/>
   <attribute name="location" type="String" value="face"/>
 </variable>
 

--- a/yaml2ncml/yaml2ncml.py
+++ b/yaml2ncml/yaml2ncml.py
@@ -161,7 +161,7 @@ def add_var_atts(text, a):
         else:
             text += str_att('display', 'False')
 
-        text += str_att('content_coverage_type', 'modelResult')
+        text += str_att('coverage_content_type', 'modelResult')
         if var in rho_vars:
             text += str_att('location', 'face')
         elif var in u_vars:


### PR DESCRIPTION
Yipes! We were setting `content_coverage_type` instead of `coverage_content_type`
https://geo-ide.noaa.gov/wiki/index.php?title=ISO_19115_and_19115-2_CodeList_Dictionaries#MD_CoverageContentTypeCode
